### PR TITLE
pre-commit fails aws credentials check issue

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,6 +52,7 @@ repos:
       - id: debug-statements
       - id: detect-private-key
       - id: detect-aws-credentials
+        args: [--allow-missing-credentials]
       - id: mixed-line-ending
         args: [--fix=lf]
       - id: no-commit-to-branch


### PR DESCRIPTION
pre-commit fails saying aws credentials were not found. Adding an argument to allow missing credentials fixes the issue.

Brief description of what this PR does and why.

## Checklist

- [x] I have created an issue for this change (not mandatory for small changes)
- [x] My changes are to-the-point
- [x] Code is styled as the rest of the codebase and linting passes
- [x] I have tested my changes locally and they work as expected
- [x] I have updated the documentation (if needed)
- [x] I have reviewed the code myself once and I don't see any issues

## Additional Notes

Any additional context or notes for reviewers.
