### PR TITLE
Use Redis properly

### DIFF
--- a/mxtoai/api.py
+++ b/mxtoai/api.py
@@ -35,7 +35,18 @@ from mxtoai.validators import (
 
 # Load environment variables
 load_dotenv()
-REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+
+# Redis Configuration
+REDIS_HOST = os.getenv("REDIS_HOST", "localhost")
+REDIS_PORT = os.getenv("REDIS_PORT", "6379")
+REDIS_DB = os.getenv("REDIS_DB", "0")
+REDIS_PASSWORD = os.getenv("REDIS_PASSWORD")
+
+if REDIS_PASSWORD:
+    REDIS_URL = f"redis://:{REDIS_PASSWORD}@{REDIS_HOST}:{REDIS_PORT}/{REDIS_DB}"
+else:
+    REDIS_URL = f"redis://{REDIS_HOST}:{REDIS_PORT}/{REDIS_DB}"
+
 
 # Constants
 MAX_FILENAME_LENGTH = 100


### PR DESCRIPTION
## Description

The Redis client was using REDIS_URL env, which isn't what we have in .env.example, so the documentation was off.

## Checklist

- [ ] I have created an issue for this change (not mandatory for small changes)
- [x] My changes are to-the-point
- [x] Code is styled as the rest of the codebase and linting passes
- [ ] I have tested my changes locally and they work as expected
- [ ] I have updated the documentation (if needed)
- [x] I have reviewed the code myself once and I don't see any issues

## Additional Notes

Any additional context or notes for reviewers.
