### PR TITLE
feat(newsletter): fix immediate-send being counted in newsletter rate…

### DIFF
--- a/mxgo/config.py
+++ b/mxgo/config.py
@@ -29,11 +29,11 @@ SCHEDULED_TASKS_MAX_PER_EMAIL = 5
 
 NEWSLETTER_LIMITS_BY_PLAN = {
     UserPlan.BETA: {
-        "max_tasks": 3,
+        "max_tasks": 6,
         "min_interval_days": 7,
     },
     UserPlan.PRO: {
-        "max_tasks": 20,
+        "max_tasks": 40,
         "min_interval_days": 1,
     },
 }

--- a/mxgo/crud.py
+++ b/mxgo/crud.py
@@ -20,6 +20,7 @@ from mxgo.models import (
     TaskStatus,
     clear_task_data_if_terminal,
 )
+from mxgo.scheduling.scheduler import is_one_time_task
 
 logger = get_logger("crud")
 
@@ -242,8 +243,6 @@ def count_recurring_tasks_for_user(session: Session, user_email: str) -> int:
         Number of active recurring tasks
 
     """
-    from mxgo.scheduling.scheduler import is_one_time_task
-
     statement = (
         select(Tasks)
         .where(Tasks.email_request.op("->>")("from") == user_email)

--- a/mxgo/schemas.py
+++ b/mxgo/schemas.py
@@ -546,6 +546,7 @@ class CreateNewsletterRequest(BaseModel):
     estimated_read_time: int | None = Field(None, description="Estimated read time in minutes for the newsletter.")
     sources: list[str] | None = Field(None, description="A list of source names or URLs to use.")
     geographic_locations: list[str] | None = Field(None, description="A list of geographic locations to focus on.")
+    language: str | None = Field(None, description="Language for the newsletter content.")
     formatting_instructions: str | None = Field(
         None, description="Specific instructions on how to format the newsletter."
     )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1218,7 +1218,7 @@ class TestCreateNewsletter:
         """Mocks all external dependencies for the newsletter endpoint."""
         with (
             patch("mxgo.api.user.get_user_plan", new_callable=AsyncMock) as mock_get_plan,
-            patch("mxgo.api.crud.count_active_tasks_for_user") as mock_count_tasks,
+            patch("mxgo.api.crud.count_recurring_tasks_for_user") as mock_count_tasks,
             patch("mxgo.api.whitelist.is_email_whitelisted", new_callable=AsyncMock) as mock_is_whitelisted,
             patch("mxgo.api.Scheduler.add_job") as mock_add_job,
             patch("mxgo.api.process_email_task.send") as mock_send_task,


### PR DESCRIPTION
Closes #149 #142 #141 

- mxgo/crud.py: added count_recurring_tasks_for_user to distinguish recurring from one-time tasks.
- mxgo/schemas.py: added language field to newsletter request.
- mxgo/api.py: refactored immediate sends to skip scheduling, implemented LLM subject generation, and added date context to research prompts.
- tests/test_api.py: updated mocks and assertions to match new task-counting logic and verification methods.

## Checklist

- [x] I have created an issue for this change (not mandatory for small changes)
- [x] My changes are to-the-point
- [x] Code is styled as the rest of the codebase and linting passes
- [x] I have tested my changes locally and they work as expected
- [ ] I have updated the documentation (if needed)
- [x] I have reviewed the code myself once and I don't see any